### PR TITLE
Add reusable unit tests workflow

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,181 @@
+name: ExtDN M2 Unit Tests
+on:
+  workflow_call:
+    inputs:
+      module_name:
+        description: "Module name"
+        required: true
+        type: string
+      composer_name:
+        description: "Composer name"
+        required: true
+        type: string
+
+jobs:
+  unit-tests-2-4-6-p13-8-1:
+    name: Magento 2.4.6-p13 PHP 8.1 Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: M2 Unit Tests with Magento 2 Version 2.4.6-p13 (PHP 8.1)
+        uses: extdn/github-actions-m2/magento-unit-tests/8.1@master
+        with:
+          module_name: ${{ inputs.module_name }}
+          composer_name: ${{ inputs.composer_name }}
+          magento_version: '2.4.6-p13'
+
+  unit-tests-2-4-6-p13-8-2:
+    name: Magento 2.4.6-p13 PHP 8.2 Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: M2 Unit Tests with Magento 2 Version 2.4.6-p13 (PHP 8.2)
+        uses: extdn/github-actions-m2/magento-unit-tests/8.2@master
+        with:
+          module_name: ${{ inputs.module_name }}
+          composer_name: ${{ inputs.composer_name }}
+          magento_version: '2.4.6-p13'
+
+  unit-tests-2-4-6-p14-8-1:
+    name: Magento 2.4.6-p14 PHP 8.1 Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: M2 Unit Tests with Magento 2 Version 2.4.6-p14 (PHP 8.1)
+        uses: extdn/github-actions-m2/magento-unit-tests/8.1@master
+        with:
+          module_name: ${{ inputs.module_name }}
+          composer_name: ${{ inputs.composer_name }}
+          magento_version: '2.4.6-p14'
+
+  unit-tests-2-4-6-p14-8-2:
+    name: Magento 2.4.6-p14 PHP 8.2 Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: M2 Unit Tests with Magento 2 Version 2.4.6-p14 (PHP 8.2)
+        uses: extdn/github-actions-m2/magento-unit-tests/8.2@master
+        with:
+          module_name: ${{ inputs.module_name }}
+          composer_name: ${{ inputs.composer_name }}
+          magento_version: '2.4.6-p14'
+
+  unit-tests-2-4-7-p8-8-2:
+    name: Magento 2.4.7-p8 PHP 8.2 Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: M2 Unit Tests with Magento 2 Version 2.4.7-p8 (PHP 8.2)
+        uses: extdn/github-actions-m2/magento-unit-tests/8.2@master
+        with:
+          module_name: ${{ inputs.module_name }}
+          composer_name: ${{ inputs.composer_name }}
+          magento_version: '2.4.7-p8'
+
+  unit-tests-2-4-7-p8-8-3:
+    name: Magento 2.4.7-p8 PHP 8.3 Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: M2 Unit Tests with Magento 2 Version 2.4.7-p8 (PHP 8.3)
+        uses: extdn/github-actions-m2/magento-unit-tests/8.3@master
+        with:
+          module_name: ${{ inputs.module_name }}
+          composer_name: ${{ inputs.composer_name }}
+          magento_version: '2.4.7-p8'
+
+  unit-tests-2-4-7-p9-8-2:
+    name: Magento 2.4.7-p9 PHP 8.2 Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: M2 Unit Tests with Magento 2 Version 2.4.7-p9 (PHP 8.2)
+        uses: extdn/github-actions-m2/magento-unit-tests/8.2@master
+        with:
+          module_name: ${{ inputs.module_name }}
+          composer_name: ${{ inputs.composer_name }}
+          magento_version: '2.4.7-p9'
+
+  unit-tests-2-4-7-p9-8-3:
+    name: Magento 2.4.7-p9 PHP 8.3 Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: M2 Unit Tests with Magento 2 Version 2.4.7-p9 (PHP 8.3)
+        uses: extdn/github-actions-m2/magento-unit-tests/8.3@master
+        with:
+          module_name: ${{ inputs.module_name }}
+          composer_name: ${{ inputs.composer_name }}
+          magento_version: '2.4.7-p9'
+
+  unit-tests-2-4-8-p3-8-3:
+    name: Magento 2.4.8-p3 PHP 8.3 Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: M2 Unit Tests with Magento 2 Version 2.4.8-p3 (PHP 8.3)
+        uses: extdn/github-actions-m2/magento-unit-tests/8.3@master
+        with:
+          module_name: ${{ inputs.module_name }}
+          composer_name: ${{ inputs.composer_name }}
+          magento_version: '2.4.8-p3'
+
+  unit-tests-2-4-8-p3-8-4:
+    name: Magento 2.4.8-p3 PHP 8.4 Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: M2 Unit Tests with Magento 2 Version 2.4.8-p3 (PHP 8.4)
+        uses: extdn/github-actions-m2/magento-unit-tests/8.4@master
+        with:
+          module_name: ${{ inputs.module_name }}
+          composer_name: ${{ inputs.composer_name }}
+          magento_version: '2.4.8-p3'
+
+  unit-tests-2-4-8-p4-8-3:
+    name: Magento 2.4.8-p4 PHP 8.3 Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: M2 Unit Tests with Magento 2 Version 2.4.8-p4 (PHP 8.3)
+        uses: extdn/github-actions-m2/magento-unit-tests/8.3@master
+        with:
+          module_name: ${{ inputs.module_name }}
+          composer_name: ${{ inputs.composer_name }}
+          magento_version: '2.4.8-p4'
+
+  unit-tests-2-4-8-p4-8-4:
+    name: Magento 2.4.8-p4 PHP 8.4 Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: M2 Unit Tests with Magento 2 Version 2.4.8-p4 (PHP 8.4)
+        uses: extdn/github-actions-m2/magento-unit-tests/8.4@master
+        with:
+          module_name: ${{ inputs.module_name }}
+          composer_name: ${{ inputs.composer_name }}
+          magento_version: '2.4.8-p4'
+
+  unit-tests-2-4-9-8-4:
+    name: Magento 2.4.9 PHP 8.4 Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: M2 Unit Tests with Magento 2 Version 2.4.9 (PHP 8.4)
+        uses: extdn/github-actions-m2/magento-unit-tests/8.4@master
+        with:
+          module_name: ${{ inputs.module_name }}
+          composer_name: ${{ inputs.composer_name }}
+          magento_version: '2.4.9'
+
+  unit-tests-2-4-9-8-5:
+    name: Magento 2.4.9 PHP 8.5 Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: M2 Unit Tests with Magento 2 Version 2.4.9 (PHP 8.5)
+        uses: extdn/github-actions-m2/magento-unit-tests/8.5@master
+        with:
+          module_name: ${{ inputs.module_name }}
+          composer_name: ${{ inputs.composer_name }}
+          magento_version: '2.4.9'


### PR DESCRIPTION
Adds a centralised unit.yml reusable workflow covering the full PHP/Magento version matrix (PHP 8.1–8.5, Magento 2.4.6-p13–2.4.9). Modules can now call this single workflow so new PHP/Magento versions only need to be added here, not in every individual module repo.